### PR TITLE
ATS-752: Alfresco-helloworld-transformer fabric8 issue

### DIFF
--- a/alfresco-helloworld-transformer-engine/pom.xml
+++ b/alfresco-helloworld-transformer-engine/pom.xml
@@ -46,7 +46,7 @@
             </plugin>
             <plugin>
                 <groupId>io.fabric8</groupId>
-                <artifactId>fabric8-maven-plugin</artifactId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <images>
                         <image>
@@ -71,7 +71,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
-                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>build-image</id>

--- a/alfresco-helloworld-transformer-engine/pom.xml
+++ b/alfresco-helloworld-transformer-engine/pom.xml
@@ -75,7 +75,7 @@
                         <executions>
                             <execution>
                                 <id>build-image</id>
-                                <phase>install</phase>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>


### PR DESCRIPTION
- Replace `fabric8-maven-plugin` with `docker-maven-plugin`, and `build-image` `phase` from `install` to `package`.
