### PR TITLE
ACS-4819 Add DependaBot Docker configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: "/alfresco-helloworld-transformer-engine"
+  schedule:
+    interval: daily
+    time: "22:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 99
+- package-ecosystem: docker
+  directory: "/helloworld-t-engine"
+  schedule:
+    interval: daily
+    time: "22:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 99


### PR DESCRIPTION
Adding Docker configuration for DependaBot to this repository so that we can upgrade the base images semi-automatically.